### PR TITLE
Optimize imports to lighten dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,16 +12,16 @@ setup(
         'numpy',
         'scipy',
         'tqdm',
-        'librosa',
+        'resampy',
         'pystoi',
         'museval',
         'gammatone @ git+https://github.com/detly/gammatone',
         'pypesq @ git+https://github.com/vBaiCai/python-pesq',
-        'srmrpy @ git+https://github.com/jfsantos/SRMRpy'
+        'srmrpy @ git+https://github.com/jfsantos/SRMRpy',
     ],
     extras_require={
-        'cpu': ['tensorflow==2.0.0'],
-        'gpu': ['tensorflow-gpu==2.0.0'],
+        'cpu': ['tensorflow==2.0.0', 'librosa'],
+        'gpu': ['tensorflow-gpu==2.0.0', 'librosa'],
     },
     include_package_data=True
 )

--- a/speechmetrics/absolute/mosnet/__init__.py
+++ b/speechmetrics/absolute/mosnet/__init__.py
@@ -1,7 +1,5 @@
-import tensorflow as tf
-
-
 def load(window, hop=None):
+    import tensorflow as tf
     from .model import MOSNet
     tf.debugging.set_log_device_placement(False)
     # set memory growth

--- a/speechmetrics/absolute/srmr/__init__.py
+++ b/speechmetrics/absolute/srmr/__init__.py
@@ -1,8 +1,9 @@
-from .srmr import srmr
 from ... import Metric
 
 
 class SRMR(Metric):
+    from .srmr import srmr
+
     def __init__(self, window, hop=None):
         super(SRMR, self).__init__(name='SRMR', window=window, hop=hop)
 

--- a/speechmetrics/absolute/srmr/__init__.py
+++ b/speechmetrics/absolute/srmr/__init__.py
@@ -2,8 +2,6 @@ from ... import Metric
 
 
 class SRMR(Metric):
-    from .srmr import srmr
-
     def __init__(self, window, hop=None):
         super(SRMR, self).__init__(name='SRMR', window=window, hop=hop)
 
@@ -18,4 +16,5 @@ class SRMR(Metric):
 
 
 def load(window, hop=None):
+    from .srmr import srmr
     return SRMR(window, hop)

--- a/speechmetrics/absolute/srmr/__init__.py
+++ b/speechmetrics/absolute/srmr/__init__.py
@@ -10,11 +10,11 @@ class SRMR(Metric):
         self.absolute = True
 
     def test_window(self, audios, rate):
+        from .srmr import srmr
         return {'srmr': srmr(audios[0], self.fixed_rate, n_cochlear_filters=23,
                              low_freq=125, min_cf=4,
                              max_cf=128, fast=True, norm=False)[0]}
 
 
 def load(window, hop=None):
-    from .srmr import srmr
     return SRMR(window, hop)


### PR DESCRIPTION
Dynamic imports are done everywhere in the package. 
With these ones, the dependency to tensorflow and librosa are only necessary when using MOSNet.