### PR TITLE
Fix bss_eval for window=None

### DIFF
--- a/speechmetrics/relative/bsseval.py
+++ b/speechmetrics/relative/bsseval.py
@@ -1,11 +1,12 @@
+import numpy as np
 from .. import Metric
 
 
 class BSSEval(Metric):
     def __init__(self, window, hop=None):
         super(BSSEval, self).__init__(name='BSSEval', window=None, hop=None)
-        self.bss_window = window
-        self.bss_hop = hop if hop is not None else window
+        self.bss_window = window if window is not None else np.inf
+        self.bss_hop = hop if hop is not None else self.bss_window
 
     def test_window(self, audios, rate):
         from museval.metrics import bss_eval


### PR DESCRIPTION
This was a bug. 
`examples/test.py` only checked for a fixed window. 

Setting `window=None` raised : 
```
Traceback (most recent call last):
  File "test.py", line 32, in <module>
    scores = metrics(reference, test)
  File "/home/mparient/code_perso/cloned/speechmetrics/speechmetrics/__init__.py", line 103, in __call__
    result_metric = metric.test(*files)
  File "/home/mparient/code_perso/cloned/speechmetrics/speechmetrics/__init__.py", line 81, in test
    result = self.test_window(audios, rate)
  File "/home/mparient/code_perso/cloned/speechmetrics/speechmetrics/relative/bsseval.py", line 16, in test_window
    window=self.bss_window * rate,
TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'
```