### PR TITLE
Numpy array support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ The process is to:
       gives the length in seconds of the windows on which to compute the actual scores. If None, the whole signals will be considered.  
     ```my_metrics = speechmetrics.load('relative', window=5)```
 
-2. Just call the object returned by `load` with your estimated file (and your reference in case of relative metrics.)  
-   ```scores = my_metrics(path_to_estimate, path_to_reference)```
+2. Just call the object returned by `load` with your estimated file (and your reference in case of relative metrics.)    
+   ```scores = my_metrics(path_to_estimate, path_to_reference)```  
+   Numpy arrays are also supported, but the corresponding sampling rate needs to be specified  
+   ```scores = my_metrics(estimate_array, reference_array, rate=sampling_rate)```
 > __WARNING__: The convention for relative metrics is to provide __estimate first, and reference second__.  
 >  This is the opposite as the general convention.  
 >     => The advantage is: you can still call absolute metrics with the same code, they will just ignore the reference.  

--- a/examples/test.py
+++ b/examples/test.py
@@ -31,3 +31,23 @@ if __name__ == '__main__':
         print('Computing scores for ', test)
         scores = metrics(reference, test)
         pprint.pprint(scores)
+
+    print('\nTrying RELATIVE metrics from numpy arrays: ')
+
+    import soundfile as sf
+    metrics = sm.load('relative', window)
+
+    reference = 'data/m2_script1_produced.wav'
+    ref_wav, rate = sf.read(reference)
+    tests = ['data/m2_script1_clean.wav',
+             'data/m2_script1_ipad_confroom1.wav',
+             'data/m2_script1_produced.wav']
+    for test in tests:
+        import pprint
+        print('Computing scores for ', test)
+        test_wav, test_rate = sf.read(test)
+        assert rate == test_rate
+        scores = metrics(ref_wav, test_wav, rate=rate)
+        pprint.pprint(scores)
+
+

--- a/speechmetrics/__init__.py
+++ b/speechmetrics/__init__.py
@@ -20,7 +20,7 @@ class Metric:
 
     def test(self, *test_files, array_rate=None):
         """loading sound files and making sure they all have the same lengths
-        (zero-padding to the largest).
+        (zero-padding to the largest). Also works with numpy arrays.
         Then, calling the `test_window` function that should be specialised
         depending on the metric."""
 

--- a/speechmetrics/__init__.py
+++ b/speechmetrics/__init__.py
@@ -18,7 +18,7 @@ class Metric:
     def test_window(self, audios, rate):
         raise NotImplementedError
 
-    def test(self, *test_files):
+    def test(self, *test_files, array_rate=None):
         """loading sound files and making sure they all have the same lengths
         (zero-padding to the largest).
         Then, calling the `test_window` function that should be specialised
@@ -42,7 +42,21 @@ class Metric:
 
         for file in test_files:
             # Loading sound file
-            audio, rate = sf.read(file, always_2d=True)
+            if isinstance(file, str):
+                audio, rate = sf.read(file, always_2d=True)
+            else:
+                rate = array_rate
+                if rate is None:
+                    raise ValueError('Sampling rate needs to be specified '
+                                     'when feeding numpy arrays.')
+                audio = file
+                # Standardize shapes
+                if len(audio.shape) == 1:
+                    audio = audio[:, None]
+                if len(audio.shape) != 2:
+                    raise ValueError('Please provide 1D or 2D array, received '
+                                     '{}D array'.format(len(audio.shape)))
+
             if self.fixed_rate is not None and rate != self.fixed_rate:
                 if self.verbose:
                     print('  [%s] preferred is %dkHz rate. resampling'
@@ -97,10 +111,10 @@ class MetricsList:
     def __str__(self):
         return 'Metrics: ' + ' '.join([x.name for x in self.metrics])
 
-    def __call__(self, *files):
+    def __call__(self, *files, rate=None):
         result = {}
         for metric in self.metrics:
-            result_metric = metric.test(*files)
+            result_metric = metric.test(*files, array_rate=rate)
             for name in result_metric.keys():
                 result[name] = result_metric[name]
         return result


### PR DESCRIPTION
This PR brings support for numpy arrays. 

They can be passed the same way to a `MetricsList` instance, with the difference that a sampling_rate needs to be specified as well. 
It further assumes that sampling rates of the estimate and reference signals are the same (which is typically the case, but I thought I should clarify it).